### PR TITLE
Documentation

### DIFF
--- a/Sources/Coalescing Operators/Coalescing_Operators.swift
+++ b/Sources/Coalescing Operators/Coalescing_Operators.swift
@@ -96,6 +96,101 @@ public func ??? <C: Collection>(optional: C?, defaultValue: @autoclosure () thro
     return try defaultValue()
 }
 
+/// Performs an empty-coalescing operation, returning the non-empty value of either a
+/// `Collection` instance or a default value.
+///
+/// An empty-coalescing operation returns the left-hand side
+/// `Collection` if it is not empty, or
+/// it returns the right-hand side as a default. The result of this operation
+/// will be the same type as its arguments. It cannot
+/// guarantee that the the result is not empty if the default value is empty, however.
+///
+/// This operator uses short-circuit evaluation: `value` is checked first,
+/// and `defaultValue` is evaluated only if `value` is empty. For example:
+///
+///     func getDefault() -> String {
+///         print("Calculating default...")
+///         return "New Item"
+///     }
+///
+///     let name = "AB"
+///
+///     let goodName = String(name.dropLast()) ??? getDefault()
+///     // goodName == "A"
+///
+///     let notSoGoodName = String(name.dropLast(2)) ??? getDefault()
+///     // Prints "Calculating default..."
+///     // notSoGoodName == "New Item"
+///
+/// In this example, `goodName` is assigned a value of `"A"` because
+/// `name.dropLast()` succeeds in returning a non-empty result. When
+/// `notSoGoodName` is initialized, `name.dropLast(2)` returns
+/// an empty `String`, and so the `getDefault()` method is called
+/// to supply a default value.
+///
+/// Because the result of this empty-coalescing operation
+/// is itself may be empty, you can chain default values by using `???`
+/// multiple times. The first value that isn't empty stops the chain and
+/// becomes the result of the whole expression.
+///
+/// - Parameters:
+///   - value: A potentially empty `Collection`.
+///   - defaultValue: A value to use as a default. `defaultValue` is the same
+///     type of `value`.
+public func ??? <C: Collection>(value: C, defaultValue: @autoclosure () throws -> C) rethrows -> C {
+    if !value.isEmpty {
+        return value
+    }
+    return try defaultValue()
+}
+
+/// Performs an empty-coalescing operation, returning the non-empty value of a
+/// `Collection` instance or a wrapped default `Optional` value.
+///
+/// An empty-coalescing operation returns the left-hand side
+/// `Collection` if it is not empty, or
+/// it returns the unwrapped right-hand side as a default if it has a value. The result of this operation
+/// will be the same type as its left-hand side.
+///
+/// This operator uses short-circuit evaluation: `value` is checked first,
+/// and `defaultValue` is evaluated only if `value` is or empty. For example:
+///
+///     let name = "AB"
+///     let number: Int? = 10
+///
+///     let goodName = String(name.dropLast()) ??? number?.description
+///     print(goodName)
+///     // Prints "Optional("A")"
+///
+///     let notSoGoodName = String(name.dropLast(2)) ??? number?.description
+///     print(notSoGoodName)
+///     // Prints "Optional("10")"
+///
+/// In this example, `goodName` is assigned a value of `"A"` because
+/// `name.dropLast()` succeeds in returning a non-empty result. When
+/// `notSoGoodName` is initialized, `name.dropLast(2)` returns
+/// an empty `String`, and so `number?.description` is called
+/// to supply a default value.
+///
+/// Because the result of this empty-coalescing operation is
+/// itself an optional value that also may be empty, you can chain default values
+/// by using `???` multiple times. The first optional value that isn't `nil` or
+/// empty stops the chain and becomes the result of the whole expression.
+///
+/// - Parameters:
+///   - value: A potentially empty `Collection`.
+///   - defaultValue: A value to use as a default. `defaultValue` is an `Optional` of the
+///     type of `value`.
+public func ??? <C: Collection>(value: C, defaultValue: @autoclosure () throws -> C?) rethrows -> C {
+    if !value.isEmpty {
+        return value
+    }
+    if let newValue = try defaultValue() {
+        return newValue
+    }
+    return value
+}
+
 //MARK: ?=
 
 infix operator ?=: NilCoalescingPrecedence

--- a/Sources/Coalescing Operators/Coalescing_Operators.swift
+++ b/Sources/Coalescing Operators/Coalescing_Operators.swift
@@ -2,13 +2,14 @@
 
 infix operator ???: NilCoalescingPrecedence
 
-/// Performs a empty-coalescing operation, returning the non-empty value of either a
-/// `Collection` or wrapped `Optional` instance or a default value.
+/// Performs an empty-coalescing operation, returning the non-empty value of either a
+/// `Collection` or wrapped `Optional Collection` instance or a default value.
 ///
-/// A empty-coalescing operation unwraps the left-hand side
+/// An empty-coalescing operation unwraps the left-hand side
 /// `Collection` if it has a value and returns it if it is not empty, or
 /// it returns the right-hand side as a default. The result of this operation
-/// will have the non-optional type of the left-hand side's `Wrapped` type.
+/// will have the non-optional type of the left-hand side's `Wrapped` type. It cannot
+/// guarantee that the the result is not empty if the default value is empty, however.
 ///
 /// This operator uses short-circuit evaluation: `optional` is checked first,
 /// and `defaultValue` is evaluated only if `optional` is `nil` or empty. For example:
@@ -39,7 +40,7 @@ infix operator ???: NilCoalescingPrecedence
 /// becomes the result of the whole expression.
 ///
 /// - Parameters:
-///   - optional: An optional or potentially empty collection.
+///   - optional: An optional or potentially empty `Collection`.
 ///   - defaultValue: A value to use as a default. `defaultValue` is the same
 ///     type as the `Wrapped` type of `optional`.
 public func ??? <C: Collection>(optional: C?, defaultValue: @autoclosure () throws -> C) rethrows -> C {
@@ -50,10 +51,10 @@ public func ??? <C: Collection>(optional: C?, defaultValue: @autoclosure () thro
     return try defaultValue()
 }
 
-/// Performs a empty-coalescing operation, returning the non-empty value of either a
-/// `Collection` or wrapped `Optional` instance or a default `Optional` value.
+/// Performs an empty-coalescing operation, returning the non-empty value of either a
+/// `Collection` or wrapped `Optional Collection` instance or a default `Optional` value.
 ///
-/// A empty-coalescing operation unwraps the left-hand side
+/// An empty-coalescing operation unwraps the left-hand side
 /// `Collection` if it has a value and returns it if it is not empty, or
 /// it returns the right-hand side as a default. The result of this operation
 /// will be the same type as its arguments.
@@ -84,7 +85,7 @@ public func ??? <C: Collection>(optional: C?, defaultValue: @autoclosure () thro
 /// empty stops the chain and becomes the result of the whole expression.
 ///
 /// - Parameters:
-///   - optional: An optional or potentially empty collection.
+///   - optional: An optional or potentially empty `Collection`.
 ///   - defaultValue: A value to use as a default. `defaultValue` is the same
 ///     type as the `Wrapped` type of `optional`.
 public func ??? <C: Collection>(optional: C?, defaultValue: @autoclosure () throws -> C?) rethrows -> C? {
@@ -135,7 +136,7 @@ infix operator ?=: NilCoalescingPrecedence
 ///     print(dict["Forty-two"])
 ///     // Prints "Optional(42)"
 ///
-/// In this example, `goodNumber` is assigned a value of `1` and `dict` is
+/// In this example, `goodNumber` is assigned a value of `1` and `dict["One"]` is
 /// unchanged because `dict["One"]` succeeded in returning a non-`nil` result.
 /// When `notSoGoodNumber` is initialized, `dict["Forty-two"]` returns
 /// `nil`, and so the `getDefault()` method is called to supply a default
@@ -190,7 +191,7 @@ public func ?= <T>(optional: inout T?, defaultValue: @autoclosure () throws -> T
 ///     print(dict["Forty-two"])
 ///     // Prints "Optional(42)"
 ///
-/// In this example, `goodNumber` is assigned a value of `1` and `dict` is
+/// In this example, `goodNumber` is assigned a value of `1` and `dict["One"]` is
 /// unchanged because `dict["One"]` succeeded in returning a non-`nil` result.
 /// When `notSoGoodNumber` is initialized, `dict["Forty-two"]` returns
 /// `nil`, and so the `getDefault()` method is called to supply a default
@@ -217,6 +218,56 @@ public func ?= <T>(optional: inout T?, defaultValue: @autoclosure () throws -> T
 
 infix operator ??=: NilCoalescingPrecedence
 
+/// Performs an empty-coalescing assignment operation, returning the non-empty value
+/// of a mutable property that is either an instance of or wrapped `Optional`
+/// of `Collection` or assigning it to and returning a default value.
+///
+/// An empty-coalescing assignment operation unwraps the left-hand side
+/// `Collection` if it has a value and returns it if it is not empty, or
+/// assigns it to and returns the right-hand side as a default. The result of this operation
+/// will have the non-optional type of the left-hand side's `Wrapped` type. It cannot
+/// guarantee that the the result is not empty if the default value is empty, however.
+///
+/// This operator uses short-circuit evaluation: `optional` is checked first,
+/// and `defaultValue` is evaluated only if `optional` is `nil` or empty.
+/// Because `optional` is an `inout` property, it will trigger `didSet`
+/// even if its value is not changed. For example:
+///
+///     func getDefault() -> String {
+///     print("Calculating default...")
+///         return "Apple"
+///     }
+///
+///     var lastNames = ["John": "Smith", "Tim": ""] {
+///         didSet {
+///             print("lastNames updated")
+///         }
+///     }
+///
+///     let goodName = lastNames["John"] ??= getDefault()
+///     // Prints "lastNames updated"
+///     // goodName == "Smith"
+///     print(lastNames["John"])
+///     // Prints "Optional("Smith")"
+///
+///     let notSoGoodName = lastNames["Tim"] ??= getDefault2()
+///     // Prints "Calculating default..."
+///     // Prints "lastNames updated"
+///     // notSoGoodName == "Apple"
+///     print(lastNames["Tim"])
+///     // Prints "Optional("Apple")"
+///
+/// In this example, `goodName` is assigned a value of `"Smith"` and
+/// `lastNames["John"]` is unchanged because `lastNames["John"]`
+/// succeeds in returning a non-empty result. When `notSoGoodName` is
+/// initialized, `lastNames["Tim"]` returns an empty `String`, and so the
+/// `getDefault()` method is called to supply a default value which is
+/// assigned to `lastNames["Tim"]` and returned.
+///
+/// - Parameters:
+///   - optional: An optional or potentially empty, mutable `Collection`.
+///   - defaultValue: A value to use as a default. `defaultValue` is the same
+///     type as the `Wrapped` type of `optional`.
 public func ??= <C: Collection>(optional: inout C?, defaultValue: @autoclosure () throws -> C) rethrows -> C {
     if let value = optional,
        !value.isEmpty {

--- a/Sources/Coalescing Operators/Coalescing_Operators.swift
+++ b/Sources/Coalescing Operators/Coalescing_Operators.swift
@@ -242,3 +242,28 @@ public func ??= <C: Collection>(optional: inout C?, defaultValue: @autoclosure (
     return optional
 }
 
+public func ??= <C: Collection>(value: inout C, defaultValue: @autoclosure () throws -> C) rethrows -> C {
+    if !value.isEmpty {
+        return value
+    }
+    let newValue = try defaultValue()
+    if !newValue.isEmpty {
+        value = newValue
+        return newValue
+    }
+    return value
+}
+
+public func ??= <C: Collection>(value: inout C, defaultValue: @autoclosure () throws -> C?) rethrows -> C? {
+    if !value.isEmpty {
+        return value
+    }
+    if let newValue = try defaultValue(),
+       !newValue.isEmpty {
+        // Only write to `optional` if `defaultValue`
+        // itself also isn't nil or empty.
+        value = newValue
+        return newValue
+    }
+    return value
+}


### PR DESCRIPTION
Adds in-code documentation to the operators.

Also adds two more ??= functions that work with non-optional left-hand sides.